### PR TITLE
[COOK-2739] Upgrade OSSEC to version 2.7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,8 @@
 
 # general settings
 default['ossec']['server_role'] = "ossec_server"
-default['ossec']['checksum']    = "258b9a24936e6b61e0478b638e8a3bfd3882d91e"
-default['ossec']['version']     = "2.6"
+default['ossec']['checksum']    = "721aa7649d5c1e37007b95a89e685af41a39da43"
+default['ossec']['version']     = "2.7"
 default['ossec']['url']         = "http://www.ossec.net/files/ossec-hids-#{node['ossec']['version']}.tar.gz"
 default['ossec']['logs']        = []
 default['ossec']['syscheck_freq'] = 79200


### PR DESCRIPTION
OSSEC is shipping version 2.7. Let's do that too!

http://tickets.opscode.com/browse/COOK-2739
