### PR TITLE
[COOK-2740] Use FQDN for a client name

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -33,7 +33,7 @@ search(:node, "ossec:[* TO *] NOT role:#{node['ossec']['server_role']}") do |n|
   ssh_hosts << n['ipaddress'] if n['keys']
 
   execute "#{agent_manager} -a --ip #{n['ipaddress']} -n #{n['fqdn'][0..31]}" do
-    not_if "grep '#{n['fqdn']} #{n['ipaddress']}' #{node['ossec']['user']['dir']}/etc/client.keys"
+    not_if "grep '#{n['fqdn'][0..31]} #{n['ipaddress']}' #{node['ossec']['user']['dir']}/etc/client.keys"
   end
 
 end


### PR DESCRIPTION
In the case where hosts have the same name, but different subdomains
we should use FQDN. Also, the Perl program driving the
configuration only accepts a max of 32 characters for a name.
