### PR TITLE
Add knob to disable ossec.conf generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Default values are based on the defaults from OSSEC's own install.sh installatio
 * `node['ossec']['logs']` - Array of log files to analyze. Default is an empty array. These are in addition to the default logs in the ossec.conf.erb template.
 * `node['ossec']['syscheck_freq']` - Frequency that syscheck is executed, default 22 hours (79200 seconds)
 * `node['ossec']['server']['maxagents']` - Maximum number of agents, default setting is 256, but will be set to 1024 in the ossec::server recipe if used. Add as an override attribute in the `ossec_server` role if more nodes are required.
+* `node['ossec']['disable_config_generation']` - Boolean that dictates whether this cookbook should drop the ossec.conf template or not. This is useful if you're using a wrapper cookbook and would like to generate your own template.
 
 The `user` attributes are used to populate the config file (ossec.conf) and preload values for the installation script.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['ossec']['version']     = "2.7"
 default['ossec']['url']         = "http://www.ossec.net/files/ossec-hids-#{node['ossec']['version']}.tar.gz"
 default['ossec']['logs']        = []
 default['ossec']['syscheck_freq'] = 79200
+default['ossec']['disable_config_generation'] = false
 
 # server-only
 default['ossec']['server']['maxagents'] = 256

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,6 +61,7 @@ template "#{node['ossec']['user']['dir']}/etc/ossec.conf" do
   mode 0440
   variables(:ossec => node['ossec']['user'])
   notifies :restart, "service[ossec]"
+  not_if { node['ossec']['disable_config_generation'] }
 end
 
 case node['platform']


### PR DESCRIPTION
Rather than fork this cookbook to make the appropriate modifications, it's preferable to use a wrapper cookbook. Since you'll almost certainly want to modify the ossec.conf template, I've added a knob to disable it's generation in the default recipe. In this way, anyone who wishes to use a wrapper cookbook can generate a custom template without conflicting.
