### PR TITLE
Add support for storing OSSEC keys in an encrypted data bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Default values are based on the defaults from OSSEC's own install.sh installatio
 * `node['ossec']['url']` - URL to download the source.
 * `node['ossec']['logs']` - Array of log files to analyze. Default is an empty array. These are in addition to the default logs in the ossec.conf.erb template.
 * `node['ossec']['syscheck_freq']` - Frequency that syscheck is executed, default 22 hours (79200 seconds)
+* `node['ossec']['data_bag']['encrypted']` - Boolean value which indicates whether or not the OSSEC data bag is encrypted
+* `node['ossec']['data_bag']['name']` - The name of the data bag to use
+* `node['ossec']['data_bag']['ssh']` - The name of the data bag item which contains the OSSEC keys
 * `node['ossec']['server']['maxagents']` - Maximum number of agents, default setting is 256, but will be set to 1024 in the ossec::server recipe if used. Add as an override attribute in the `ossec_server` role if more nodes are required.
 
 The `user` attributes are used to populate the config file (ossec.conf) and preload values for the installation script.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,11 @@ default['ossec']['url']         = "http://www.ossec.net/files/ossec-hids-#{node[
 default['ossec']['logs']        = []
 default['ossec']['syscheck_freq'] = 79200
 
+# data bag configuration
+default['ossec']['data_bag']['encrypted']  = false
+default['ossec']['data_bag']['name']       = "ossec"
+default['ossec']['data_bag']['ssh']        = "ssh"
+
 # server-only
 default['ossec']['server']['maxagents'] = 256
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -34,7 +34,13 @@ node.save
 
 include_recipe "ossec"
 
-ossec_key = data_bag_item("ossec", "ssh")
+dbag_name = node["ossec"]["data_bag"]["name"]
+dbag_item = node["ossec"]["data_bag"]["ssh"]
+if node["ossec"]["data_bag"]["encrypted"]
+  ossec_key = Chef::EncryptedDataBagItem.load(dbag_name, dbag_item)
+else
+  ossec_key = data_bag_item(dbag_name, dbag_item)
+end
 
 user "ossecd" do
   comment "OSSEC Distributor"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -47,7 +47,13 @@ template "/usr/local/bin/dist-ossec-keys.sh" do
   not_if { ssh_hosts.empty? }
 end
 
-ossec_key = data_bag_item("ossec", "ssh")
+dbag_name = node["ossec"]["data_bag"]["name"]
+dbag_item = node["ossec"]["data_bag"]["ssh"]
+if node["ossec"]["data_bag"]["encrypted"]
+  ossec_key = Chef::EncryptedDataBagItem.load(dbag_name, dbag_item)
+else
+  ossec_key = data_bag_item(dbag_name, dbag_item)
+end
 
 directory "#{node['ossec']['user']['dir']}/.ssh" do
   owner "root"


### PR DESCRIPTION
Since we use a data bag to store the OSSEC SSH certificate, we should really support encrypted data bags. I've left the default to false for backwards compatibility. Also, making the data bag name and item configurable.
