### PR TITLE
Add support for cloud ip detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Default values are based on the defaults from OSSEC's own install.sh installatio
 * `node['ossec']['logs']` - Array of log files to analyze. Default is an empty array. These are in addition to the default logs in the ossec.conf.erb template.
 * `node['ossec']['syscheck_freq']` - Frequency that syscheck is executed, default 22 hours (79200 seconds)
 * `node['ossec']['server']['maxagents']` - Maximum number of agents, default setting is 256, but will be set to 1024 in the ossec::server recipe if used. Add as an override attribute in the `ossec_server` role if more nodes are required.
+* `node['ossec']['server']['cloud_public_addr']` - Under default configuration, OSSEC will use `node.ipaddress` to map IP's to chef nodes. Enabling this attribute will cause it to use `node.cloud.public_ips` instead. If the node is not in the cloud, it will fall back to `node.ipaddress`
 
 The `user` attributes are used to populate the config file (ossec.conf) and preload values for the installation script.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ default['ossec']['syscheck_freq'] = 79200
 
 # server-only
 default['ossec']['server']['maxagents'] = 256
+default['ossec']['server']['cloud_public_addr'] = false
 
 # used to populate config files and preload values for install
 default['ossec']['user']['language'] = "en"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -23,7 +23,11 @@ if node.run_list.roles.include?(node['ossec']['server_role'])
   ossec_server << node['ipaddress']
 else
   search(:node,"role:#{node['ossec']['server_role']}") do |n|
-    ossec_server << n['ipaddress']
+    if n['ossec']['server']['cloud_public_addr'] && n['cloud']
+      ossec_server << n['cloud']['public_ips'].first
+    else
+      ossec_server << n['ipaddress']
+    end
   end
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -30,10 +30,16 @@ ssh_hosts = Array.new
 
 search(:node, "ossec:[* TO *] NOT role:#{node['ossec']['server_role']}") do |n|
 
-  ssh_hosts << n['ipaddress'] if n['keys']
+  if node['ossec']['server']['cloud_public_addr'] && n['cloud']
+    ipaddress = n['cloud']['public_ips'].first
+  else
+    ipaddress = n['ipaddress']
+  end
 
-  execute "#{agent_manager} -a --ip #{n['ipaddress']} -n #{n['fqdn'][0..31]}" do
-    not_if "grep '#{n['fqdn'][0..31]} #{n['ipaddress']}' #{node['ossec']['user']['dir']}/etc/client.keys"
+  ssh_hosts << ipaddress if n['keys']
+
+  execute "#{agent_manager} -a --ip #{ipaddress} -n #{n['fqdn'][0..31]}" do
+    not_if "grep '#{n['fqdn'][0..31]} #{ipaddress}' #{node['ossec']['user']['dir']}/etc/client.keys"
   end
 
 end


### PR DESCRIPTION
When running OSSEC on an infrastructure that spans multiple cloud providers, using `node.ipaddress` is not effective as the hosted machine is frequently NAT'd. This results in the clients trying to use a private address to communicate with the OSSEC server on a different network.

In order to work around this problem, I'd like to introduce an attribute which will instruct the recipes to consult the node's cloud attribute in order to obtain public addresses. This allows the infrastructure to span multiple cloud providers. Since most providers have reachability on both public and private addresses, there should be no caveats other than a change in the network route.

Default is disabled for backward compatibility.
