### PR TITLE
Don't use node.save in OSSEC recipes

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -30,8 +30,6 @@ end
 node.set['ossec']['user']['install_type'] = "agent"
 node.set['ossec']['user']['agent_server_ip'] = ossec_server.first
 
-node.save
-
 include_recipe "ossec"
 
 ossec_key = data_bag_item("ossec", "ssh")

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -20,8 +20,6 @@
 node.set['ossec']['user']['install_type'] = "server"
 node.set['ossec']['server']['maxagents']  = 1024
 
-node.save
-
 include_recipe "ossec"
 
 agent_manager = "#{node['ossec']['user']['dir']}/bin/ossec-batch-manager.pl"


### PR DESCRIPTION
Using node.save is considered toxic, to be used only when absolutely necessary. I do not see a need for it to be here (maybe historical?), but this particular node.save has begun to cause issues when something later on in the run fails. In that case, we are saving an incomplete set of attributes, and searches occurring on other nodes return unexpected data as a result.

Let's just get rid of it.
