### PR TITLE
add init script for rhel platform

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,13 +63,19 @@ template "#{node['ossec']['user']['dir']}/etc/ossec.conf" do
   notifies :restart, "service[ossec]"
 end
 
-case node['platform']
-when "arch"
-  template "/etc/rc.d/ossec" do
-    source "ossec.rc.erb"
-    owner "root"
-    mode 0755
-  end
+case node['platform_family']
+  when "arch"
+    template "/etc/rc.d/ossec" do
+      source "ossec.rc.erb"
+      owner "root"
+      mode 0755
+    end
+  when "rhel"
+    template "/etc/init.d/ossec" do
+      source "ossec.init.erb"
+      owner "root"
+      mode 0755
+    end
 end
 
 service "ossec" do

--- a/templates/default/ossec.init.erb
+++ b/templates/default/ossec.init.erb
@@ -1,0 +1,53 @@
+#!/bin/sh
+# OSSEC         Controls OSSEC HIDS
+# Author:       Daniel B. Cid <dcid@ossec.net>
+# Modified for RHEL
+#
+# chkconfig: 2345 99 15
+# description:    OSSEC-HIDS is an Open Source Host-based Intrusion \
+#                 Detection System.
+# config: /etc/ossec-init.conf
+
+# Source function library.
+. /etc/init.d/functions
+
+# Source configuration.
+[ -r /etc/ossec-init.conf ] && source /etc/ossec-init.conf
+
+if [ "X${DIRECTORY}" = "X" ]; then
+  DIRECTORY="<%= node['ossec']['user']['dir'] %>"
+fi
+
+
+start() {
+  ${DIRECTORY}/bin/ossec-control start
+}
+
+stop() {
+  ${DIRECTORY}/bin/ossec-control stop
+}
+
+status() {
+  ${DIRECTORY}/bin/ossec-control status
+}
+
+
+case "$1" in
+  start)
+    start
+  ;;
+  stop)
+    stop
+  ;;
+  restart)
+    stop
+    start
+  ;;
+  status)
+    status
+  ;;
+  *)
+    echo "usage: $0 {start|stop|restart|status}"
+    exit 1
+esac
+


### PR DESCRIPTION
The `default` recipe fails with the error below because the install does not create an init.d file.
This pull request provides the init script for the rhel platform.

```
  * service[ossec] action start[2013-10-31T05:17:56+00:00] INFO: Processing service[ossec] action start (ossec::default line 75)

    * service[ossec]: unable to locate the init.d script!
================================================================================
Error executing action `start` on resource 'service[ossec]'
================================================================================


Chef::Exceptions::Service
-------------------------
service[ossec]: unable to locate the init.d script!


Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/ossec/recipes/default.rb

 75: service "ossec" do
 76:   supports :status => true, :restart => true
 77:   action [:enable, :start]
 78: end
```
