### PR TITLE
Add depends for include_recipe working with testkitchen

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,9 @@ description      "Installs/Configures ossec"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.5"
 
-depends "build-essential"
+%w{ build-essential apt apache2 }.each do |pkg|
+  depends pkg
+end
 
 %w{ debian ubuntu arch redhat centos fedora }.each do |os|
   supports os


### PR DESCRIPTION
We need to set all dependencies in metadata with using include_recipe methods.
