### PR TITLE
Support for partial search

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,7 @@ default['ossec']['version']     = "2.7"
 default['ossec']['url']         = "http://www.ossec.net/files/ossec-hids-#{node['ossec']['version']}.tar.gz"
 default['ossec']['logs']        = []
 default['ossec']['syscheck_freq'] = 79200
+default['ossec']['use_partial_search'] = false
 default['ossec']['disable_config_generation'] = false
 
 # data bag configuration

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      "Installs/Configures ossec"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.5"
 
-%w{ build-essential apt apache2 }.each do |pkg|
+%w{ build-essential apt apache2 partial_search }.each do |pkg|
   depends pkg
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -30,7 +30,15 @@ search_string = "ossec:[* TO *]"
 search_string << " AND chef_environment:#{node['ossec']['server_env']}" if node['ossec']['server_env']
 search_string << " NOT role:#{node['ossec']['server_role']}"
 
-search(:node, search_string) do |n|
+if node['ossec']['use_partial_search']
+  search_keys = { 'fqdn' => ['fqdn'],
+                  'ipaddress' => ['ipaddress'] }
+  node_data = partial_search(:node, search_string, :keys => search_keys)
+else
+  node_data = search(:node, search_string)
+end
+
+node_data.each do |n|
 
   ssh_hosts << n['ipaddress'] if n['keys']
 


### PR DESCRIPTION
If `node['ossec']['use_partial_search']` is set to true, use a partial search instead of a full node search to avoid running the node out of memory.
