### PR TITLE
agent_auth and authd recipes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,3 +34,19 @@ suites:
   run_list:
     - recipe[ossec::server]
   data_bags_path: 'test/fixtures/data_bags'
+- name: agent_auth
+  run_list:
+    - recipe[ossec::agent_auth]
+  attributes:
+    ossec:
+      agent_server_ip: 10.0.2.2
+- name: authd
+  run_list:
+    - recipe[ossec::authd]
+  driver_config:
+    network:
+    - ['forwarded_port', { guest: 1514, host: 1514, protocol: 'udp' }]
+    - ['forwarded_port', { guest: 1515, host: 1515, protocol: 'tcp' }]
+  includes:
+    - centos-7.2
+    - debian-8.4

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ To manage additional agents on the server that don't run chef, or for agentless 
 
 Enable agentless monitoring in OSSEC and register the hosts on the server. Automated configuration of agentless nodes is not yet supported by this cookbook. For more information on the commands and configuration directives required in `ossec.conf`, see the [OSSEC Documentation](http://www.ossec.net/doc/manual/agent/agentless-monitoring.html)
 
+### agent_auth
+
+If you do not wish to distribute agent keys via SSH then the authd mechanism provides an alternative. Set the `agent_server_ip` attribute manually and this recipe will attempt to register with the given server running ossec-authd. To allow registration with a new server after changing `agent_server_ip`, delete the client.keys file and rerun the recipe.
+
+### authd
+
+For a server to accept agent registrations, it needs to be running ossec-authd. This recipe installs an init script for it (systemd only for now) and will attempt to start it once the mandatory SSL certificate and key have been put in place. From OSSEC 2.9, you can also set a CA certificate to validate agents against.
+
 ## Usage
 
 The cookbook can be used to install OSSEC in one of the three types:

--- a/attributes/authd.rb
+++ b/attributes/authd.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook Name:: ossec
+# Attributes:: authd
+#
+# Copyright 2015, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['ossec']['authd']['ip_address'] = false
+default['ossec']['authd']['port'] = 1515
+
+default['ossec']['authd']['ca'] = nil
+default['ossec']['authd']['certificate'] = "#{node['ossec']['dir']}/etc/sslmanager.cert"
+default['ossec']['authd']['key'] = "#{node['ossec']['dir']}/etc/sslmanager.key"
+
+default['ossec']['agent_auth']['name'] = node['fqdn']
+default['ossec']['agent_auth']['host'] = node['ossec']['agent_server_ip']
+default['ossec']['agent_auth']['port'] = node['ossec']['authd']['port']
+
+default['ossec']['agent_auth']['ca'] = nil
+default['ossec']['agent_auth']['certificate'] = nil
+default['ossec']['agent_auth']['key'] = nil

--- a/recipes/agent_auth.rb
+++ b/recipes/agent_auth.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: ossec
+# Recipe:: agent_auth
+#
+# Copyright 2015, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'ossec::install_agent'
+
+dir = node['ossec']['dir']
+agent_auth = node['ossec']['agent_auth']
+
+args = "-m #{agent_auth['host']} -p #{agent_auth['port']} -A #{agent_auth['name']}"
+
+if agent_auth['ca'] && File.exist?(agent_auth['ca'])
+  args << ' -v ' + agent_auth['ca']
+end
+
+if agent_auth['certificate'] && File.exist?(agent_auth['certificate'])
+  args << ' -x ' + agent_auth['certificate']
+end
+
+if agent_auth['key'] && File.exist?(agent_auth['key'])
+  args << ' -k ' + agent_auth['key']
+end
+
+execute "#{dir}/bin/agent-auth #{args}" do
+  timeout 30
+  ignore_failure true
+  only_if { agent_auth['host'] && !File.size?("#{dir}/etc/client.keys") }
+end
+
+include_recipe 'ossec::common'

--- a/recipes/authd.rb
+++ b/recipes/authd.rb
@@ -1,0 +1,50 @@
+#
+# Cookbook Name:: ossec
+# Recipe:: authd
+#
+# Copyright 2015, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'ossec::install_server'
+include_recipe 'ossec::common'
+
+authd = node['ossec']['authd']
+
+if node['init_package'] == 'systemd'
+  template 'ossec-authd init' do
+    path '/lib/systemd/system/ossec-authd.service'
+    source 'ossec-authd.service.erb'
+    owner 'root'
+    group 'root'
+    mode 0644
+    variables authd
+  end
+
+  execute 'systemctl daemon-reload' do
+    action :nothing
+    subscribes :run, 'template[ossec-authd init]', :immediately
+  end
+end
+
+service 'ossec-authd' do
+  supports restart: true
+  action [:enable, :start]
+  subscribes :restart, 'template[ossec-authd init]'
+
+  only_if do
+    File.exist?(authd['certificate']) && File.exist?(authd['key']) &&
+      (authd['ca'].nil? || File.exist?(authd['ca']))
+  end
+end

--- a/templates/default/ossec-authd.service.erb
+++ b/templates/default/ossec-authd.service.erb
@@ -1,0 +1,8 @@
+[Unit]
+Description=OSSEC authd
+
+[Service]
+EnvironmentFile=/etc/ossec-init.conf
+Environment=DIRECTORY=/var/ossec
+
+ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-authd -p <%= @port %> <%= '-i' if @ip_address %> -x <%= @certificate %> -k <%= @key %> <%= "-v #{@ca}" if @ca %>


### PR DESCRIPTION
I'm not keen on the SSH solution, especially with both agent and server certificate verification arriving in 2.9 so I've added these recipes. They support the new certificate options but I haven't tested those yet.

This is based on my earlier packages pull request in #47. I'll rebase this one when that one gets merged, if necessary.

I really wanted to rename the existing client and server recipes to something less generic as the addition of this new approach now makes the cookbook confusing. However, I decided not to as I didn't want to upset the existing users. Perhaps now would be a good time for a clean break though as #47 will probably not be a seamless upgrade anyway. With certificate verification arriving in 2.9, perhaps this approach should replace the SSH solution entirely? The former certainly seems safer to me. Feedback on this point would be appreciated.

Only a systemd init script is provided for authd. Sorry about that.

You can easily test these recipes yourself using Kitchen. Converge the authd system first, then login, create a self-signed certificate, and converge again to start authd. On converging the agent_auth system, it should register automatically. You will need to converge the authd system one final time to actually get the server to start as client.keys would have been empty the first time around.
