### PR TITLE
Pretty print XML config for better readability

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -53,7 +53,19 @@ class Chef
 
       def self.ossec_to_xml(hash)
         require 'gyoku'
-        Gyoku.xml object_to_ossec(hash)
+        xml = Gyoku.xml object_to_ossec(hash)
+        xml_pretty_print(xml)
+      end
+
+      # => The Gyoku version with Pretty Print is not on Rubygems
+      def self.xml_pretty_print(xml)
+        require 'rexml/document'
+        result = ''
+        formatter = REXML::Formatters::Pretty.new 2
+        formatter.compact = true
+        doc = REXML::Document.new xml
+        formatter.write doc, result
+        result
       end
     end
   end


### PR DESCRIPTION
This enables pretty print for the XML config.  The current Gyoku RubyGems release does not have this functionality.  XML is already a pain in the ass to read, this makes it less painful.

It'd be nice to see a supermarket release of the current version of this cookbook, the concept here with Hash -> XML is great.