### PR TITLE
Update metadata.rb and CHANGELOG for version 2.0.0, fixes #88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# v2.0.0
+
+## Bug
+
+- [6cb5e39] Replace `rc` with `systemd` service configuration for Arch Linux
+- [3b581e6] Find ossec_client nodes in Chef
+- [0836d80] Fix `service_name` on Debian
+
+## Improvement
+
+- [a823be7] Add Web UI support and associated documentation
+- [f8a11a1] Add partial node search support
+- [b6c55dc] Improve testing, style, and documentation
+- [02ae9a6] Upgrade OSSEC to version 2.8.3
+- [0836d80] Add explicit `os` support for scientific/oracle/amazon platforms
+- Various other testing improvements and syntax cleanup
+
+## Breaking Changes
+
+- [b00b396] Move to attribute driven configuration
+
 # v1.0.5
 
 ## Bug

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Installs and configures ossec'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.5'
+version          '2.0.0'
 
 %w( apt yum-atomic ).each do |pkg|
   depends pkg


### PR DESCRIPTION
Increases cookbook version to ~1.1.0~ 2.0.0. I tried going through the many changes since the last supermarket release and highlighted the most important ones in the CHANGELOG.



- [x] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable