### PR TITLE
Fixed search query according to the doc

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,7 +23,7 @@ ssh_hosts = []
 
 search_string = 'ossec:[* TO *]'
 search_string << " AND chef_environment:#{node['ossec']['server_env']}" if node['ossec']['server_env']
-search_string << " AND NOT role:#{node['ossec']['server_role']} AND NOT fqdn:#{node['fqdn']}"
+search_string << " AND (NOT role:#{node['ossec']['server_role']}) AND (NOT fqdn:#{node['fqdn']})"
 
 filter_keys = { 'fqdn' => ['fqdn'], 'ipaddress' => ['ipaddress'] }
 


### PR DESCRIPTION
### Description

Fix the search query in `ossec::server` recipe. Actual query return a 400 Bad request.

https://docs.chef.io/knife_search.html#not

### Issues Resolved

This fix the issue:
```
[2017-10-02T11:20:28+00:00] WARN: ossec:[* TO *] AND chef_environment:_default AND NOT role:ossec-server AND NOT fqdn:myfqdn
[2017-10-02T11:20:28+00:00] INFO: HTTP Request Returned 400 Bad Request: error

================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/ossec/recipes/server.rb
================================================================================

Net::HTTPServerException
------------------------
400 "Bad Request"

Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/ossec/recipes/server.rb:31:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/ossec/recipes/server.rb:

 24:  search_string = 'ossec:[* TO *]'
 25:  search_string << " AND chef_environment:#{node['ossec']['server_env']}" if node['ossec']['server_env']
 26:  search_string << " AND NOT role:#{node['ossec']['server_role']} AND NOT fqdn:#{node['fqdn']}"
 27:
 28:  Chef::Log.warn(search_string)
 29:  filter_keys = { 'fqdn' => ['fqdn'], 'ipaddress' => ['ipaddress'] }
 30:
 31>> search(:node, search_string, filter_result: filter_keys).each do |n|
 32:    ssh_hosts << n['ipaddress'] if n['keys']
 33:
 34:    execute "#{node['ossec']['agent_manager']} -a --ip #{n['ipaddress']} -n #{n['fqdn'][0..31]}" do
 35:      not_if "grep '#{n['fqdn'][0..31]} #{n['ipaddress']}' #{node['ossec']['dir']}/etc/client.keys"
 36:    end
 37:  end
 38:
 39:  template '/usr/local/bin/dist-ossec-keys.sh' do
 40:    source 'dist-ossec-keys.sh.erb'

Platform:
---------
x86_64-linux
```

If we perform a knife search with the same query:
```
> knife search node "ossec:[* TO *] AND chef_environment:_default AND NOT role:ossec-server AND NOT fqdn:myfqdn"
ERROR: knife search failed: invalid search query: 'ossec:[* TO *] AND chef_environment:_default AND NOT role:ossec-server AND NOT fqdn:myfqdn'
```

With fixed query:
```
> knife search node "ossec:[* TO *] AND chef_environment:_default AND (NOT role:ossec-server) AND (NOT fqdn:myfqdn)"
0 items found
```

### Check List
- [ ] All tests pass. See https://github.com/chef-brigade/sysctl/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
