### PR TITLE
Update repository.rb to reference new URL

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -27,7 +27,7 @@ when 'fedora', 'rhel'
 when 'debian'
   apt_repository 'ossec' do
     uri "https://updates.atomicorp.com/channels/atomic/#{node['platform']}"
-    key 'https://updates.atomicorp.com/installers/RPM-GPG-KEY.atomicorp.txt'
+    key 'https://www.atomicorp.com/RPM-GPG-KEY.atomicorp.txt'
     arch ossec_deb_arch
     distribution ossec_apt_repo_dist
     trusted true if ossec_apt_new_layout?


### PR DESCRIPTION
# Description

Old URL has been removed from the mirror, new URL is the new location on upstream's mirror.

## Issues Resolved

https://github.com/sous-chefs/ossec/issues/178

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
