### PR TITLE
fix: repair release workflow validation

### DIFF
--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -2,15 +2,22 @@
 name: prevent-file-change
 
 "on":
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   prevent-file-change:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@5.0.3
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,4 +1,5 @@
 config:
+  ul-style: false # MD004 - release-please generates "*" in CHANGELOG.md
   ul-indent: false # MD007
   line-length: false # MD013
   no-duplicate-heading: false # MD024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,24 @@ Standardise files with files in sous-chefs/repo-management
 
 ## Unreleased
 
-- Convert the cookbook to a full custom-resource layout under `resources/`
-- Remove legacy `recipes/` and `attributes/` content
-- Modernize supported platforms and align Kitchen and CI with the current matrix
-- Add `LIMITATIONS.md`, resource documentation, test cookbook recipes, and resource-focused ChefSpec/InSpec coverage
+* Convert the cookbook to a full custom-resource layout under `resources/`
+* Remove legacy `recipes/` and `attributes/` content
+* Modernize supported platforms and align Kitchen and CI with the current matrix
+* Add `LIMITATIONS.md`, resource documentation, test cookbook recipes, and resource-focused ChefSpec/InSpec coverage
 
 ## [2.0.18](https://github.com/sous-chefs/ossec/compare/v2.0.17...v2.0.18) (2025-10-16)
 
 
 ### Bug Fixes
 
-- **ci:** Update workflows to use release pipeline ([#188](https://github.com/sous-chefs/ossec/issues/188)) ([1cc004a](https://github.com/sous-chefs/ossec/commit/1cc004ad272354130c96be8018ccd3d17c35ee06))
+* **ci:** Update workflows to use release pipeline ([#188](https://github.com/sous-chefs/ossec/issues/188)) ([1cc004a](https://github.com/sous-chefs/ossec/commit/1cc004ad272354130c96be8018ccd3d17c35ee06))
 
 ## [2.0.17](https://github.com/sous-chefs/ossec/compare/2.0.16...v2.0.17) (2025-10-15)
 
 
 ### Bug Fixes
 
-- **ci:** Update workflows to use release pipeline ([#188](https://github.com/sous-chefs/ossec/issues/188)) ([1cc004a](https://github.com/sous-chefs/ossec/commit/1cc004ad272354130c96be8018ccd3d17c35ee06))
+* **ci:** Update workflows to use release pipeline ([#188](https://github.com/sous-chefs/ossec/issues/188)) ([1cc004a](https://github.com/sous-chefs/ossec/commit/1cc004ad272354130c96be8018ccd3d17c35ee06))
 
 ## 2.0.16 - *2025-09-04*
 
@@ -68,54 +68,54 @@ Standardise files with files in sous-chefs/repo-management
 
 ## 2.0.0 - *2023-01-12*
 
-- Standardise files with files in sous-chefs/repo-management
-- Partially modernize cookbook
-   - Refactor library helper
-- Properly set repositories for various supported platforms
-- Cleanup and Fix CI
-- Add support to various platforms
-- Fix idempotency issues
+* Standardise files with files in sous-chefs/repo-management
+* Partially modernize cookbook
+   * Refactor library helper
+* Properly set repositories for various supported platforms
+* Cleanup and Fix CI
+* Add support to various platforms
+* Fix idempotency issues
 
 ## 1.2.7 - *2022-02-08*
 
-- Standardise files with files in sous-chefs/repo-management
+* Standardise files with files in sous-chefs/repo-management
 
 ## 1.2.6 - *2022-02-07*
 
-- Remove delivery folder
-- Standardise files with files in sous-chefs/repo-management
+* Remove delivery folder
+* Standardise files with files in sous-chefs/repo-management
 
 ## 1.2.5 - *2021-09-08*
 
-- resolved cookstyle error: recipes/authd.rb:25:4 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper`
+* resolved cookstyle error: recipes/authd.rb:25:4 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper`
 
 ## 1.2.4 - *2021-08-30*
 
-- Standardise files with files in sous-chefs/repo-management
+* Standardise files with files in sous-chefs/repo-management
 
 ## 1.2.3 - *2021-06-01*
 
-- resolved cookstyle error: spec/unit/recipes/agent_spec.rb:5:31 convention: `Style/ExpandPathArguments`
-- resolved cookstyle error: spec/unit/recipes/client_spec.rb:5:31 convention: `Style/ExpandPathArguments`
-- resolved cookstyle error: spec/unit/recipes/server_spec.rb:5:31 convention: `Style/ExpandPathArguments`
+* resolved cookstyle error: spec/unit/recipes/agent_spec.rb:5:31 convention: `Style/ExpandPathArguments`
+* resolved cookstyle error: spec/unit/recipes/client_spec.rb:5:31 convention: `Style/ExpandPathArguments`
+* resolved cookstyle error: spec/unit/recipes/server_spec.rb:5:31 convention: `Style/ExpandPathArguments`
 
 ## 1.2.2 - 2020-05-14
 
-- resolved cookstyle error: recipes/common.rb:20:35 convention: `Layout/TrailingWhitespace`
-- resolved cookstyle error: recipes/common.rb:20:36 refactor: `ChefModernize/FoodcriticComments`
-- resolved cookstyle error: recipes/common.rb:90:24 convention: `Layout/TrailingWhitespace`
-- resolved cookstyle error: recipes/common.rb:90:25 refactor: `ChefModernize/FoodcriticComments`
+* resolved cookstyle error: recipes/common.rb:20:35 convention: `Layout/TrailingWhitespace`
+* resolved cookstyle error: recipes/common.rb:20:36 refactor: `ChefModernize/FoodcriticComments`
+* resolved cookstyle error: recipes/common.rb:90:24 convention: `Layout/TrailingWhitespace`
+* resolved cookstyle error: recipes/common.rb:90:25 refactor: `ChefModernize/FoodcriticComments`
 
 ## 1.2.1 - 2020-05-05
 
 ### Added
 
-- Migration to Github Actions
+* Migration to Github Actions
 
 ### Changed
 
-- Various Cookstyle and foodcritic fixes
-- resolved cookstyle error: libraries/helpers.rb:31:18 convention: `Style/HashEachMethods`
+* Various Cookstyle and foodcritic fixes
+* resolved cookstyle error: libraries/helpers.rb:31:18 convention: `Style/HashEachMethods`
 
 ### Deprecated
 
@@ -125,7 +125,7 @@ Standardise files with files in sous-chefs/repo-management
 
 ### Added
 
-- Add distro based authd service name
+* Add distro based authd service name
 
 ### Changed
 
@@ -135,31 +135,31 @@ Standardise files with files in sous-chefs/repo-management
 
 ## [1.1.0] - 2018-08-13
 
-- README Updates:
-   - Fix broken links
-   - Add reference to Wazzuh
-- General updates to cookbook
-   - Remove EOL distros
-   - Update for current supported Chef version (13)
+* README Updates:
+   * Fix broken links
+   * Add reference to Wazzuh
+* General updates to cookbook
+   * Remove EOL distros
+   * Update for current supported Chef version (13)
 
 ## [1.0.5] - 2014-04-15
 
-- Avoid node.save to prevent incomplete attribute collections
-- `dist-ossec-keys.sh` should be sorted for idempotency
-- Ability to disable ossec configuration template
-- Support for encrypted databags
-- Support for environment-scoped searches
-- Support for multiple email_to addresses
+* Avoid node.save to prevent incomplete attribute collections
+* `dist-ossec-keys.sh` should be sorted for idempotency
+* Ability to disable ossec configuration template
+* Support for encrypted databags
+* Support for environment-scoped searches
+* Support for multiple email_to addresses
 
 ## [1.0.4] - 2013-05-14
 
-- [COOK-2740]: Use FQDN for a client name
-- [COOK-2739]: Upgrade OSSEC to version 2.7
+* [COOK-2740]: Use FQDN for a client name
+* [COOK-2739]: Upgrade OSSEC to version 2.7
 
 ## [1.0.2] - 2012-07-01
 
-- [COOK-1394] - update ossec to version 2.6
+* [COOK-1394] - update ossec to version 2.6
 
 ## 1.0.0
 
-- Initial/current release
+* Initial/current release


### PR DESCRIPTION
## Summary
- run the prevent-file-change reusable workflow with `pull_request_target` and explicit PR write permissions
- allow release-generated `*` bullets in markdownlint
- normalize the existing `CHANGELOG.md` list markers to `*` for consistency with release-please output

## Verification
- `yamllint .github/workflows/prevent-file-change.yml`
- `markdownlint-cli2 "**/*.md" "!vendor/**"`